### PR TITLE
add some check for @cufunc

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -105,7 +105,7 @@ _cufunc(mod,ex) = begin
     if ~isdefined(mod,f)                # definition check
         Core.eval(mod,ex)
     elseif ~@eval $mod.$f isa Function  # name check
-        error("$f already has a value, can't define cu$f")
+        error("$f already has a value, can't define cufunc_$f")
     end
     def[:name] = Symbol(:cufunc_, f)    # As the definition not in CUDA, a longer prefix to prevent something like msum(x) = ....
     def[:body] = replace_device(def[:body])


### PR DESCRIPTION
At present, `@cufunc` is able to generate a CUDA ver for existing function, like `Base.cis()`.  
However, if we want to use `@cufunc` for user defined functions, we must write the definition twice: first without `@cufunc`, then with it. This seems to be an unnecessary repetition.
On the other hand, if user only write the definition with  `@cufunc` , the const `_cufuncs` will be polluted, i.e.
```julia
julia> f
ERROR: UndefVarError: f not defined

julia> :f in CUDA.cufuncs()
false

julia> CUDA.@cufunc f(x) = x+1
ERROR: UndefVarError: f not defined
Stacktrace:
 [1] top-level scope at ~\.julia\packages\CUDA\dZvbp\src\broadcast.jl:110

julia> :f in CUDA.cufuncs()
true
```

This PR add a existence check and a name check:
1. If there's no existed method, then define a cpu version first.
2. If the function name is used as a variable, throw a error.  

As there's no document for this macro, I'm not clear about the role of this macro in CUDA.jl. If i misunderstood its usage, just close this PR.